### PR TITLE
Report proto refactor- Purge Command

### DIFF
--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -45,6 +45,7 @@ class JCarbonCallback(Callback):
         self.signals = signals
 
     def start_jcarbon(self):
+        self.client.purge()
         self.client.start(self.pid, self.period_ms)
 
     def stop_jcarbon(self):


### PR DESCRIPTION
Added the purge command before starting each epoch. Purpose is to collect jcarbon data for the current epoch, saves memory. 