### PR TITLE
added new callback for collecting batch timestamps

### DIFF
--- a/experiments/bert_finetune/bert_glue_finetune.py
+++ b/experiments/bert_finetune/bert_glue_finetune.py
@@ -13,7 +13,7 @@ import pandas as pd
 import tensorflow_addons as tfa
 
 from jcarbon.report import to_dataframe
-from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2, JCarbonNvmlCallback, JCarbonChunkingCallback3
+from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2, JCarbonNvmlCallback, JCarbonExperimentCallback
 
 bert_model_name = 'small_bert/bert_en_uncased_L-2_H-128_A-2'
 
@@ -414,7 +414,7 @@ def main():
 
     # do the actual training
     print(f'Training model with {tfhub_handle_encoder}')
-    jcarb = JCarbonChunkingCallback3(
+    jcarb = JCarbonExperimentCallback(
         period_ms=args.sampling_period_millis,
         chunking_period_sec=args.collection_period_secs,
     )

--- a/experiments/bert_finetune/bert_glue_finetune.py
+++ b/experiments/bert_finetune/bert_glue_finetune.py
@@ -13,7 +13,7 @@ import pandas as pd
 import tensorflow_addons as tfa
 
 from jcarbon.report import to_dataframe
-from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2, NvmlSampleCallback, JCarbonExperimentCallback
+from jcarbon.tensorflow.callbacks import JCarbonExperimentCallback
 
 bert_model_name = 'small_bert/bert_en_uncased_L-2_H-128_A-2'
 
@@ -414,7 +414,7 @@ def main():
 
     # do the actual training
     print(f'Training model with {tfhub_handle_encoder}')
-    jcarb = JCarbonExperimentCallback(
+    jcarb = NvmlSamplerCallback(
         period_ms=args.sampling_period_millis,
         chunking_period_sec=args.collection_period_secs,
     )

--- a/experiments/bert_finetune/bert_glue_finetune.py
+++ b/experiments/bert_finetune/bert_glue_finetune.py
@@ -13,7 +13,7 @@ import pandas as pd
 import tensorflow_addons as tfa
 
 from jcarbon.report import to_dataframe
-from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2
+from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2, JCarbonNvmlCallback, JCarbonChunkingCallback3
 
 bert_model_name = 'small_bert/bert_en_uncased_L-2_H-128_A-2'
 
@@ -414,7 +414,7 @@ def main():
 
     # do the actual training
     print(f'Training model with {tfhub_handle_encoder}')
-    jcarb = JCarbonChunkingCallback2(
+    jcarb = JCarbonChunkingCallback3(
         period_ms=args.sampling_period_millis,
         chunking_period_sec=args.collection_period_secs,
     )
@@ -433,6 +433,10 @@ def main():
     print(f'writing jcarbon report to {output_path}')
     pd.concat(list(jcarb.reports.values())).to_csv(output_path)
 
+    #this is a hack atm, need to fix
+    tokenize = output_path.split('report.csv')
+    timestamps_output = tokenize[0] + 'timestamps.csv'
+    pd.concat(list(jcarb.timestamps.values())).to_csv(timestamps_output, index = False)
 
 if __name__ == '__main__':
     main()

--- a/experiments/bert_finetune/bert_glue_finetune.py
+++ b/experiments/bert_finetune/bert_glue_finetune.py
@@ -13,7 +13,7 @@ import pandas as pd
 import tensorflow_addons as tfa
 
 from jcarbon.report import to_dataframe
-from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2, JCarbonNvmlCallback, JCarbonExperimentCallback
+from jcarbon.tensorflow.callbacks import JCarbonChunkingCallback, JCarbonChunkingCallback2, NvmlSampleCallback, JCarbonExperimentCallback
 
 bert_model_name = 'small_bert/bert_en_uncased_L-2_H-128_A-2'
 

--- a/experiments/bert_finetune/bert_glue_finetune.py
+++ b/experiments/bert_finetune/bert_glue_finetune.py
@@ -414,7 +414,7 @@ def main():
 
     # do the actual training
     print(f'Training model with {tfhub_handle_encoder}')
-    jcarb = NvmlSamplerCallback(
+    jcarb = JCarbonExperimentCallback(
         period_ms=args.sampling_period_millis,
         chunking_period_sec=args.collection_period_secs,
     )

--- a/experiments/bert_finetune/bert_glue_finetune.py
+++ b/experiments/bert_finetune/bert_glue_finetune.py
@@ -433,9 +433,8 @@ def main():
     print(f'writing jcarbon report to {output_path}')
     pd.concat(list(jcarb.reports.values())).to_csv(output_path)
 
-    #this is a hack atm, need to fix
-    tokenize = output_path.split('report.csv')
-    timestamps_output = tokenize[0] + 'timestamps.csv'
+    timestamps_output = os.path.join(os.path.dirname(output_path), 'timestamps.csv')
+    print(f'writing jcarbon batch timestamps report to {timestamps_output}')
     pd.concat(list(jcarb.timestamps.values())).to_csv(timestamps_output, index = False)
 
 if __name__ == '__main__':

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -1,11 +1,14 @@
 import os
 import time
 import pandas as pd
+import json
 
 from tensorflow.keras.callbacks import Callback
 
 from jcarbon.client import JCarbonClient
 from jcarbon.report import to_dataframe
+
+from jcarbon.nvml.sampler import create_report, NvmlSampler
 
 DEFAULT_PERIOD_MS = 10
 DEFAULT_PERIOD_SECS = 2
@@ -185,3 +188,100 @@ class JCarbonDumpingEpochCallback(JCarbonCallback):
         self.client.stop(self.pid)
         self.client.dump(
             self.pid, f'{self.output_path}/report-{epoch}.pb', self.signals)
+
+class JCarbonNvmlCallback(JCarbonCallback):
+    def __init__(
+            self,
+            addr='localhost:8980',
+            period_ms=DEFAULT_PERIOD_MS,
+            signals=DEFAULT_SIGNALS,
+            chunking_period_sec=DEFAULT_PERIOD_SECS):
+        super().__init__(addr, period_ms, signals)
+        self.reports = {}
+        self.sampler = NvmlSampler()
+    
+    def on_epoch_begin(self, epoch, logs = None):
+        self.last_report = None
+        self.sampler.sample()
+    
+    def on_epoch_end(self, epoch, logs = None):
+        self.sampler.sample()
+        if self.last_report is None:
+            self.last_report = [create_report(self.sampler.samples)]
+            print('in none)')
+            print(self.last_report)
+        else:
+            self.last_report.append(create_report(self.sampler.samples))
+            print(self.last_report)
+
+        self.reports[epoch] = pd.concat(list(map(
+            to_dataframe,
+            self.last_report
+        ))).to_frame().assign(
+            epoch=epoch).set_index('epoch', append=True)
+
+class JCarbonChunkingCallback3(JCarbonCallback):
+    def __init__(
+            self,
+            addr='localhost:8980',
+            period_ms=DEFAULT_PERIOD_MS,
+            signals=DEFAULT_SIGNALS,
+            chunking_period_sec=DEFAULT_PERIOD_SECS):
+        super().__init__(addr, period_ms, signals)
+        self.reports = {}
+        self.timestamps = {}
+        self.batch_timestamps = None
+        self.batch_idx = None
+        self.epoch_idx = None
+        self.chunking_period_sec = chunking_period_sec
+
+    def on_epoch_begin(self, epoch, logs=None):
+        self.time = time.time()
+        self.last_report = None
+        self.curr_batch_timestamps = None
+        if self.epoch_idx is None:
+            self.epoch_idx = 1
+        else:
+            self.epoch_idx+=1
+        self.start_jcarbon()
+    
+    def on_train_batch_begin(self, epoch, logs=None):
+        self.batch_start = time.time()
+        if self.batch_idx is None:
+            self.batch_idx = 1
+        else:
+            self.batch_idx+=1
+        
+    def on_train_batch_end(self, epoch, logs=None):
+        curr = time.time()
+        if (curr - self.time > self.chunking_period_sec):
+            self.time = curr
+            if self.last_report is None:
+                self.last_report = [self.stop_jcarbon()]
+            else:
+                self.last_report.append(self.stop_jcarbon())
+            self.start_jcarbon()
+        self.batch_end = int((10**9 * curr))
+        self.batch_start = int((10**9 * self.batch_start))
+        if self.curr_batch_timestamps is None:
+            self.curr_batch_timestamps = [{'epoch': self.epoch_idx, 'batch': self.batch_idx, 'start': self.batch_start, 'end': self.batch_end}]
+        else:
+            self.curr_batch_timestamps.append({'epoch': self.epoch_idx, 'batch': self.batch_idx, 'start': self.batch_start, 'end': self.batch_end})
+
+    def on_epoch_end(self, epoch, logs=None):
+        if self.last_report is None:
+            self.last_report = [self.stop_jcarbon()]
+        else:
+            self.last_report.append(self.stop_jcarbon())
+        self.reports[epoch] = pd.concat(list(map(
+            to_dataframe,
+            self.last_report
+        ))).to_frame().assign(
+            epoch=epoch).set_index('epoch', append=True)
+        if self.batch_timestamps is None:
+            self.batch_timestamps = self.curr_batch_timestamps
+        else:
+            self.batch_timestamps.extend(self.curr_batch_timestamps)
+
+    def on_train_end(self, logs = None):
+        self.timestamps[self.epoch_idx] = pd.DataFrame.from_dict(self.batch_timestamps)

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -14,7 +14,6 @@ DEFAULT_PERIOD_SECS = 2
 DEFAULT_SIGNALS = [
     'nvml',
     'linux_process',
-    'linux_system',
     'JOULES',
     'GRAMS_OF_CO2',
 ]
@@ -118,9 +117,8 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
     def on_train_batch_end(self, batch, logs=None):
         curr = time.time()
         super().on_train_batch_end(batch, logs)
-        curr = int((10**9 * curr))
         self.batch_start = int((10**9 * self.batch_start))
-        self.batch_timestamps.append({'batch': batch, 'start': self.batch_start, 'end': curr})
+        self.batch_timestamps.append({'batch': batch, 'start': self.batch_start, 'end': int((10**9 * curr))})
 
     def on_epoch_end(self, epoch, logs=None):
         super().on_epoch_end(epoch, logs)

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -107,7 +107,6 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
         super().__init__(addr, period_ms, signals, chunking_period_sec)
         self.timestamps = {}
 
-
     def on_epoch_begin(self, epoch, logs=None):
         super().on_epoch_begin(epoch, logs)
         self.batch_timestamps = []
@@ -115,7 +114,6 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
     def on_train_batch_begin(self, batch, logs=None):
         self.batch_start = time.time()
         super().on_train_batch_begin(batch, logs)
-        
         
     def on_train_batch_end(self, batch, logs=None):
         curr = time.time()
@@ -132,21 +130,17 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
 class NvmlSamplerCallback(Callback):
     def __init__(self):
         self.reports = {}
-        self.sampler = NvmlSampler()
-    
+        
     def on_epoch_begin(self, epoch, logs = None):
+        self.sampler = NvmlSampler()
         self.sampler.sample()
     
     def on_epoch_end(self, epoch, logs = None):
         self.sampler.sample()
-        # self.reports[epoch] = create_report(self.sampler.samples)
-        # if self.last_report is None:
-        #     self.last_report = [create_report(self.sampler.samples)]
-        # else:
-        #     self.last_report.append(create_report(self.sampler.samples))
+        
         self.reports[epoch] = pd.concat(list(map(
             to_dataframe,
-            create_report(self.sampler.samples)
+            [create_report(self.sampler.samples)]
         ))).to_frame().assign(
             epoch=epoch).set_index('epoch', append=True)
 

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -1,7 +1,6 @@
 import os
 import time
 import pandas as pd
-import json
 
 from tensorflow.keras.callbacks import Callback
 
@@ -148,7 +147,7 @@ class JCarbonExperimentCallback(JCarbonCallback):
         self.last_report = None
         self.curr_batch_timestamps = None
         if self.epoch_idx is None:
-            self.epoch_idx = 1
+            self.epoch_idx = 0
         else:
             self.epoch_idx+=1
         self.start_jcarbon()
@@ -156,7 +155,7 @@ class JCarbonExperimentCallback(JCarbonCallback):
     def on_train_batch_begin(self, epoch, logs=None):
         self.batch_start = time.time()
         if self.batch_idx is None:
-            self.batch_idx = 1
+            self.batch_idx = 0
         else:
             self.batch_idx+=1
         
@@ -190,6 +189,7 @@ class JCarbonExperimentCallback(JCarbonCallback):
             self.batch_timestamps = self.curr_batch_timestamps
         else:
             self.batch_timestamps.extend(self.curr_batch_timestamps)
+        self.batch_idx = 0
 
     def on_train_end(self, logs = None):
         self.timestamps[self.epoch_idx] = pd.DataFrame.from_dict(self.batch_timestamps)

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -167,17 +167,17 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
         self.batch_timestamps = None
 
     def on_epoch_begin(self, epoch, logs=None):
-        super().on_epoch_begin(epoch)
+        super().on_epoch_begin(epoch, logs)
         self.curr_batch_timestamps = None
     
     def on_train_batch_begin(self, batch, logs=None):
         self.batch_start = time.time()
-        super().on_train_batch_begin(batch)
+        super().on_train_batch_begin(batch, logs)
         
         
     def on_train_batch_end(self, batch, logs=None):
         curr = time.time()
-        super().on_train_batch_end(batch)
+        super().on_train_batch_end(batch, logs)
         self.batch_end = int((10**9 * curr))
         self.batch_start = int((10**9 * self.batch_start))
         if self.curr_batch_timestamps is None:
@@ -186,7 +186,7 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
             self.curr_batch_timestamps.append({'batch': batch, 'start': self.batch_start, 'end': self.batch_end})
 
     def on_epoch_end(self, epoch, logs=None):
-        super().on_epoch_end(epoch)
+        super().on_epoch_end(epoch, logs)
         if self.batch_timestamps is None:
             self.batch_timestamps = pd.DataFrame.from_dict(self.curr_batch_timestamps)
         else:

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -128,6 +128,71 @@ class JCarbonChunkingCallback(JCarbonCallback):
         self.reports[epoch] = self.last_report.to_frame().assign(
             epoch=epoch).set_index('epoch', append=True)
 
+class JCarbonExperimentCallback(JCarbonCallback):
+    def __init__(
+            self,
+            addr='localhost:8980',
+            period_ms=DEFAULT_PERIOD_MS,
+            signals=DEFAULT_SIGNALS,
+            chunking_period_sec=DEFAULT_PERIOD_SECS):
+        super().__init__(addr, period_ms, signals)
+        self.reports = {}
+        self.timestamps = {}
+        self.batch_timestamps = None
+        self.batch_idx = None
+        self.epoch_idx = None
+        self.chunking_period_sec = chunking_period_sec
+
+    def on_epoch_begin(self, epoch, logs=None):
+        self.time = time.time()
+        self.last_report = None
+        self.curr_batch_timestamps = None
+        if self.epoch_idx is None:
+            self.epoch_idx = 1
+        else:
+            self.epoch_idx+=1
+        self.start_jcarbon()
+    
+    def on_train_batch_begin(self, epoch, logs=None):
+        self.batch_start = time.time()
+        if self.batch_idx is None:
+            self.batch_idx = 1
+        else:
+            self.batch_idx+=1
+        
+    def on_train_batch_end(self, epoch, logs=None):
+        curr = time.time()
+        if (curr - self.time > self.chunking_period_sec):
+            self.time = curr
+            if self.last_report is None:
+                self.last_report = [self.stop_jcarbon()]
+            else:
+                self.last_report.append(self.stop_jcarbon())
+            self.start_jcarbon()
+        self.batch_end = int((10**9 * curr))
+        self.batch_start = int((10**9 * self.batch_start))
+        if self.curr_batch_timestamps is None:
+            self.curr_batch_timestamps = [{'epoch': self.epoch_idx, 'batch': self.batch_idx, 'start': self.batch_start, 'end': self.batch_end}]
+        else:
+            self.curr_batch_timestamps.append({'epoch': self.epoch_idx, 'batch': self.batch_idx, 'start': self.batch_start, 'end': self.batch_end})
+
+    def on_epoch_end(self, epoch, logs=None):
+        if self.last_report is None:
+            self.last_report = [self.stop_jcarbon()]
+        else:
+            self.last_report.append(self.stop_jcarbon())
+        self.reports[epoch] = pd.concat(list(map(
+            to_dataframe,
+            self.last_report
+        ))).to_frame().assign(
+            epoch=epoch).set_index('epoch', append=True)
+        if self.batch_timestamps is None:
+            self.batch_timestamps = self.curr_batch_timestamps
+        else:
+            self.batch_timestamps.extend(self.curr_batch_timestamps)
+
+    def on_train_end(self, logs = None):
+        self.timestamps[self.epoch_idx] = pd.DataFrame.from_dict(self.batch_timestamps)
 
 class JCarbonChunkingCallback2(JCarbonCallback):
     def __init__(
@@ -208,11 +273,8 @@ class JCarbonNvmlCallback(JCarbonCallback):
         self.sampler.sample()
         if self.last_report is None:
             self.last_report = [create_report(self.sampler.samples)]
-            print('in none)')
-            print(self.last_report)
         else:
             self.last_report.append(create_report(self.sampler.samples))
-            print(self.last_report)
 
         self.reports[epoch] = pd.concat(list(map(
             to_dataframe,
@@ -220,68 +282,3 @@ class JCarbonNvmlCallback(JCarbonCallback):
         ))).to_frame().assign(
             epoch=epoch).set_index('epoch', append=True)
 
-class JCarbonChunkingCallback3(JCarbonCallback):
-    def __init__(
-            self,
-            addr='localhost:8980',
-            period_ms=DEFAULT_PERIOD_MS,
-            signals=DEFAULT_SIGNALS,
-            chunking_period_sec=DEFAULT_PERIOD_SECS):
-        super().__init__(addr, period_ms, signals)
-        self.reports = {}
-        self.timestamps = {}
-        self.batch_timestamps = None
-        self.batch_idx = None
-        self.epoch_idx = None
-        self.chunking_period_sec = chunking_period_sec
-
-    def on_epoch_begin(self, epoch, logs=None):
-        self.time = time.time()
-        self.last_report = None
-        self.curr_batch_timestamps = None
-        if self.epoch_idx is None:
-            self.epoch_idx = 1
-        else:
-            self.epoch_idx+=1
-        self.start_jcarbon()
-    
-    def on_train_batch_begin(self, epoch, logs=None):
-        self.batch_start = time.time()
-        if self.batch_idx is None:
-            self.batch_idx = 1
-        else:
-            self.batch_idx+=1
-        
-    def on_train_batch_end(self, epoch, logs=None):
-        curr = time.time()
-        if (curr - self.time > self.chunking_period_sec):
-            self.time = curr
-            if self.last_report is None:
-                self.last_report = [self.stop_jcarbon()]
-            else:
-                self.last_report.append(self.stop_jcarbon())
-            self.start_jcarbon()
-        self.batch_end = int((10**9 * curr))
-        self.batch_start = int((10**9 * self.batch_start))
-        if self.curr_batch_timestamps is None:
-            self.curr_batch_timestamps = [{'epoch': self.epoch_idx, 'batch': self.batch_idx, 'start': self.batch_start, 'end': self.batch_end}]
-        else:
-            self.curr_batch_timestamps.append({'epoch': self.epoch_idx, 'batch': self.batch_idx, 'start': self.batch_start, 'end': self.batch_end})
-
-    def on_epoch_end(self, epoch, logs=None):
-        if self.last_report is None:
-            self.last_report = [self.stop_jcarbon()]
-        else:
-            self.last_report.append(self.stop_jcarbon())
-        self.reports[epoch] = pd.concat(list(map(
-            to_dataframe,
-            self.last_report
-        ))).to_frame().assign(
-            epoch=epoch).set_index('epoch', append=True)
-        if self.batch_timestamps is None:
-            self.batch_timestamps = self.curr_batch_timestamps
-        else:
-            self.batch_timestamps.extend(self.curr_batch_timestamps)
-
-    def on_train_end(self, logs = None):
-        self.timestamps[self.epoch_idx] = pd.DataFrame.from_dict(self.batch_timestamps)

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -129,20 +129,13 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
 
 class NvmlSamplerCallback(Callback):
     def __init__(self):
-        self.reports = {}
-        
-    def on_epoch_begin(self, epoch, logs = None):
         self.sampler = NvmlSampler()
+
+    def on_epoch_begin(self, epoch, logs = None):
         self.sampler.sample()
     
     def on_epoch_end(self, epoch, logs = None):
         self.sampler.sample()
-        
-        self.reports[epoch] = pd.concat(list(map(
-            to_dataframe,
-            [create_report(self.sampler.samples)]
-        ))).to_frame().assign(
-            epoch=epoch).set_index('epoch', append=True)
 
 # TODO: these two benchmarks exist for completeness; always use the chunking callback.
 # TODO: we need the streaming response rpc for this

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -71,7 +71,7 @@ class JCarbonChunkingCallback(JCarbonCallback):
         self.last_report = None
         self.start_jcarbon()
 
-    def on_train_batch_end(self, batch, logs=None):
+    def on_train_batch_end(self, epoch, logs=None):
         curr = time.time()
         if (curr - self.time > self.chunking_period_sec):
             self.time = curr
@@ -206,7 +206,7 @@ class JCarbonChunkingCallback2(JCarbonCallback):
         self.last_report = None
         self.start_jcarbon()
 
-    def on_train_batch_end(self, batch, logs=None):
+    def on_train_batch_end(self, epoch, logs=None):
         curr = time.time()
         if (curr - self.time > self.chunking_period_sec):
             self.time = curr

--- a/service/src/main/python/jcarbon/tensorflow/callbacks.py
+++ b/service/src/main/python/jcarbon/tensorflow/callbacks.py
@@ -159,8 +159,6 @@ class JCarbonExperimentCallback(JCarbonChunkingCallback):
 
     def on_epoch_end(self, epoch, logs=None):
         super().on_epoch_end(epoch)
-        print('epoch is at epoch end')
-        print(epoch)
         if self.batch_timestamps is None:
             self.batch_timestamps = pd.DataFrame.from_dict(self.curr_batch_timestamps)
         else:


### PR DESCRIPTION
Added 2 new callbacks, one for collecting batch timestamps and gets written to a report (the current way of outputting to the file is a hack). The other one is just collecting solely nvml data, which we used for testing.