### PR TITLE
Cleared string parsing issues in CpuFrequency class 

### DIFF
--- a/src/jcarbon-proto/src/main/java/jcarbon/linux/freq/CpuFreq.java
+++ b/src/jcarbon-proto/src/main/java/jcarbon/linux/freq/CpuFreq.java
@@ -82,7 +82,7 @@ public final class CpuFreq {
   }
 
   private static int readCounter(int cpu, String component) {
-    String counter = readFromComponent(cpu, component);
+    String counter = readFromComponent(cpu, component).strip();
     if (counter.isBlank()) {
       return 0;
     }

--- a/src/jcarbon-proto/src/main/java/jcarbon/linux/freq/CpuFreq.java
+++ b/src/jcarbon-proto/src/main/java/jcarbon/linux/freq/CpuFreq.java
@@ -22,12 +22,12 @@ public final class CpuFreq {
   private static final Path SYS_CPU = Paths.get("/sys", "devices", "system", "cpu");
 
   /** Returns the expected frequency in KHz of a cpu. */
-  public static int getFrequency(int cpu) {
+  public static long getFrequency(int cpu) {
     return readCounter(cpu, "cpuinfo_cur_freq");
   }
 
   /** Returns the observed frequency in Hz of a cpu. */
-  public static int getObservedFrequency(int cpu) {
+  public static long getObservedFrequency(int cpu) {
     return 1000 * readCounter(cpu, "scaling_cur_freq");
   }
 
@@ -81,12 +81,12 @@ public final class CpuFreq {
         .build();
   }
 
-  private static int readCounter(int cpu, String component) {
+  private static long readCounter(int cpu, String component) {
     String counter = readFromComponent(cpu, component).strip();
     if (counter.isBlank()) {
       return 0;
     }
-    return Integer.parseInt(counter);
+    return Long.parseLong(counter);
   }
 
   private static synchronized String readFromComponent(int cpu, String component) {

--- a/src/jcarbon-proto/src/main/java/jcarbon/linux/freq/CpuFrequency.java
+++ b/src/jcarbon-proto/src/main/java/jcarbon/linux/freq/CpuFrequency.java
@@ -5,10 +5,10 @@ public final class CpuFrequency {
   // TODO: immutable data structures are "safe" as public
   public final int cpu;
   public final String governor;
-  public final int frequency;
-  public final int setFrequency;
+  public final long frequency;
+  public final long setFrequency;
 
-  CpuFrequency(int cpu, String governor, int frequency, int setFrequency) {
+  CpuFrequency(int cpu, String governor, long frequency, long setFrequency) {
     this.cpu = cpu;
     this.governor = governor;
     this.frequency = frequency;


### PR DESCRIPTION
Got rid of a trailing white space to fix parsing issues, as well as clearing overflow problems in `jcarbon.linux.freq`